### PR TITLE
Add environment setup script and documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,8 @@ jobs:
     - name: Set up Python
       run: uv python install 3.13
     
-    - name: Install dependencies
-      run: uv sync --group dev
-    
-    - name: Install pandoc
-      run: sudo apt-get update && sudo apt-get install -y pandoc
+    - name: Set up environment
+      run: ./scripts/setup-env.sh --group dev
     
     - name: Run tests
       run: uv run pytest --cov=src

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Run the setup script to install dependencies and ensure Pandoc is available:
 ./scripts/setup-env.sh
 ```
 
+**Note:** The setup script is designed for Unix-like systems (Linux, macOS). Windows users should install dependencies manually.
+
 To include development dependencies (e.g., for running tests), pass additional `uv sync` options:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,7 +18,19 @@ A Python tool for converting Markdown files to modern DOCX format Word documents
 
 ## Installation
 
-Install dependencies using uv:
+Run the setup script to install dependencies and ensure Pandoc is available:
+
+```bash
+./scripts/setup-env.sh
+```
+
+To include development dependencies (e.g., for running tests), pass additional `uv sync` options:
+
+```bash
+./scripts/setup-env.sh --group dev
+```
+
+Or install dependencies manually using uv:
 
 ```bash
 uv sync
@@ -73,9 +85,10 @@ output_path = converter.convert("input.md", "output.docx")
 
 # Conversion with options
 output_path = converter.convert(
-    "input.md", 
+    "input.md",
     "output.docx",
-    **{"--toc": True, "--toc-depth": 3}
+    toc=True,
+    toc_depth=3,
 )
 
 # Create modern template

--- a/README_zh.md
+++ b/README_zh.md
@@ -18,7 +18,19 @@
 
 ## 安装
 
-使用uv安装依赖：
+运行脚本安装依赖并确保系统有 Pandoc：
+
+```bash
+./scripts/setup-env.sh
+```
+
+如需包含开发依赖（例如运行测试），可以传入额外的 `uv sync` 参数：
+
+```bash
+./scripts/setup-env.sh --group dev
+```
+
+或者手动使用uv安装依赖：
 
 ```bash
 uv sync
@@ -73,9 +85,10 @@ output_path = converter.convert("input.md", "output.docx")
 
 # 带选项的转换
 output_path = converter.convert(
-    "input.md", 
+    "input.md",
     "output.docx",
-    **{"--toc": True, "--toc-depth": 3}
+    toc=True,
+    toc_depth=3,
 )
 
 # 创建现代模板

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -7,32 +7,44 @@ uv sync "$@"
 # Ensure pandoc is installed
 if ! command -v pandoc >/dev/null 2>&1; then
   echo "Pandoc not found. Attempting to install..."
-  if command -v apt-get >/dev/null 2>&1; then
-    sudo apt-get update && sudo apt-get install -y pandoc
-  elif command -v brew >/dev/null 2>&1; then
-    brew install pandoc
-  elif command -v yum >/dev/null 2>&1; then
-    sudo yum install -y pandoc
-  elif command -v dnf >/dev/null 2>&1; then
-    sudo dnf install -y pandoc
-  elif command -v pacman >/dev/null 2>&1; then
-if ! command -v pandoc >/dev/null 2>&1; then
-  echo "Pandoc not found. Attempting to install..."
-  if command -v apt-get >/dev/null 2>&1; then
-    sudo apt-get update && sudo apt-get install -y pandoc || { echo "Failed to install pandoc using apt-get"; exit 1; }
-  elif command -v brew >/dev/null 2>&1; then
+  
+  # Check if sudo is available for package managers that need it
+  has_sudo() {
+    command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null
+  }
+  
+  if command -v brew >/dev/null 2>&1; then
     brew install pandoc || { echo "Failed to install pandoc using brew"; exit 1; }
+  elif command -v apt-get >/dev/null 2>&1; then
+    if has_sudo; then
+      sudo apt-get update && sudo apt-get install -y pandoc || { echo "Failed to install pandoc using apt-get"; exit 1; }
+    else
+      echo "sudo required for apt-get. Please install pandoc manually: sudo apt-get install pandoc"
+      exit 1
+    fi
   elif command -v yum >/dev/null 2>&1; then
-    sudo yum install -y pandoc || { echo "Failed to install pandoc using yum"; exit 1; }
+    if has_sudo; then
+      sudo yum install -y pandoc || { echo "Failed to install pandoc using yum"; exit 1; }
+    else
+      echo "sudo required for yum. Please install pandoc manually: sudo yum install pandoc"
+      exit 1
+    fi
   elif command -v dnf >/dev/null 2>&1; then
-    sudo dnf install -y pandoc || { echo "Failed to install pandoc using dnf"; exit 1; }
+    if has_sudo; then
+      sudo dnf install -y pandoc || { echo "Failed to install pandoc using dnf"; exit 1; }
+    else
+      echo "sudo required for dnf. Please install pandoc manually: sudo dnf install pandoc"
+      exit 1
+    fi
   elif command -v pacman >/dev/null 2>&1; then
-    sudo pacman -Sy --noconfirm pandoc || { echo "Failed to install pandoc using pacman"; exit 1; }
+    if has_sudo; then
+      sudo pacman -Sy --noconfirm pandoc || { echo "Failed to install pandoc using pacman"; exit 1; }
+    else
+      echo "sudo required for pacman. Please install pandoc manually: sudo pacman -S pandoc"
+      exit 1
+    fi
   else
-    echo "Could not determine package manager. Please install pandoc manually."
-    exit 1
-  else
-    echo "Could not determine package manager. Please install pandoc manually."
+    echo "Could not determine package manager. Please install pandoc manually from: https://pandoc.org/installing.html"
     exit 1
   fi
 else

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Python dependencies using uv, allowing additional arguments (e.g., --group dev)
+uv sync "$@"
+
+# Ensure pandoc is installed
+if ! command -v pandoc >/dev/null 2>&1; then
+  echo "Pandoc not found. Attempting to install..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update && sudo apt-get install -y pandoc
+  elif command -v brew >/dev/null 2>&1; then
+    brew install pandoc
+  elif command -v yum >/dev/null 2>&1; then
+    sudo yum install -y pandoc
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y pandoc
+  elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm pandoc
+  else
+    echo "Could not determine package manager. Please install pandoc manually."
+    exit 1
+  fi
+else
+  echo "Pandoc already installed."
+fi

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -16,7 +16,21 @@ if ! command -v pandoc >/dev/null 2>&1; then
   elif command -v dnf >/dev/null 2>&1; then
     sudo dnf install -y pandoc
   elif command -v pacman >/dev/null 2>&1; then
-    sudo pacman -Sy --noconfirm pandoc
+if ! command -v pandoc >/dev/null 2>&1; then
+  echo "Pandoc not found. Attempting to install..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update && sudo apt-get install -y pandoc || { echo "Failed to install pandoc using apt-get"; exit 1; }
+  elif command -v brew >/dev/null 2>&1; then
+    brew install pandoc || { echo "Failed to install pandoc using brew"; exit 1; }
+  elif command -v yum >/dev/null 2>&1; then
+    sudo yum install -y pandoc || { echo "Failed to install pandoc using yum"; exit 1; }
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y pandoc || { echo "Failed to install pandoc using dnf"; exit 1; }
+  elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm pandoc || { echo "Failed to install pandoc using pacman"; exit 1; }
+  else
+    echo "Could not determine package manager. Please install pandoc manually."
+    exit 1
   else
     echo "Could not determine package manager. Please install pandoc manually."
     exit 1

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+# Check if 'uv' is installed
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Error: 'uv' is not installed or not found in your PATH."
+  echo "Please install 'uv' by following instructions at https://github.com/astral-sh/uv or run:"
+  echo "  pip install uv"
+  exit 1
+fi
+
 # Install Python dependencies using uv, allowing additional arguments (e.g., --group dev)
 uv sync "$@"
 

--- a/src/markdown2docx/cli.py
+++ b/src/markdown2docx/cli.py
@@ -49,8 +49,8 @@ Examples:
     # Prepare conversion options
     options = {}
     if args.toc:
-        options['--toc'] = True
-        options['--toc-depth'] = args.toc_depth
+        options['toc'] = True
+        options['toc_depth'] = args.toc_depth
     
     try:
         output_path = converter.convert(args.input, args.output, **options)

--- a/src/markdown2docx/cli.py
+++ b/src/markdown2docx/cli.py
@@ -28,7 +28,7 @@ Examples:
                        help="Create a modern DOCX template")
     parser.add_argument("--toc", action="store_true",
                        help="Include table of contents")
-    parser.add_argument("--toc-depth", type=int, default=3,
+    parser.add_argument("--toc-depth", "--toc_depth", type=int, default=3,
                        help="Table of contents depth (default: 3)")
     
     args = parser.parse_args()
@@ -50,7 +50,7 @@ Examples:
     options = {}
     if args.toc:
         options['toc'] = True
-        options['toc_depth'] = args.toc_depth
+        options['toc_depth'] = getattr(args, 'toc_depth', None) or args.toc_depth
     
     try:
         output_path = converter.convert(args.input, args.output, **options)

--- a/src/markdown2docx/converter.py
+++ b/src/markdown2docx/converter.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     Version = None  # Converter still works without packaging; only strict compare is skipped
 
+# Configure logger
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 

--- a/src/markdown2docx/converter.py
+++ b/src/markdown2docx/converter.py
@@ -34,6 +34,10 @@ class MarkdownToDocxConverter:
         "+bracketed_spans"
     )
 
+    def _get_modern_docx_args(self) -> list[str]:
+        """Base Pandoc arguments for modern DOCX output."""
+        return ["-f", self._DEFAULT_MD_READER, "-t", "docx+styles"]
+
     def __init__(self, reference_doc: Optional[str | Path] = None, min_pandoc: str = "2.19"):
         """
         Args:
@@ -80,7 +84,7 @@ class MarkdownToDocxConverter:
             Path to the generated DOCX file.
 
         Raises:
-            FileNotFoundError: If the input file (or reference doc) does not exist.
+            FileNotFoundError: If the input file does not exist.
             RuntimeError: If Pandoc is missing or conversion/validation fails.
         """
         input_path = Path(input_path)
@@ -115,13 +119,14 @@ class MarkdownToDocxConverter:
         self, *, toc: bool, toc_depth: int, extra_args: Optional[Sequence[str]]
     ) -> list[str]:
         """Build a predictable set of Pandoc arguments for DOCX output."""
-        args: list[str] = ["-f", self._DEFAULT_MD_READER]
+        args = self._get_modern_docx_args()
 
         # Use a reference DOCX to control styles (headings, captions, code, etc.)
         if self.reference_doc:
-            if not self.reference_doc.exists():
-                raise FileNotFoundError(f"Reference DOCX not found: {self.reference_doc}")
-            args.extend(["--reference-doc", str(self.reference_doc)])
+            if self.reference_doc.exists():
+                args.extend(["--reference-doc", str(self.reference_doc)])
+            else:
+                log.warning("Reference DOCX not found: %s. Proceeding without it.", self.reference_doc)
 
         # Optional ToC
         if toc:
@@ -137,6 +142,19 @@ class MarkdownToDocxConverter:
             args.extend(extra_args)
 
         return args
+
+    def convert_with_template(
+        self,
+        input_path: str | Path,
+        template_path: str | Path,
+        output_path: Optional[str | Path] = None,
+        **kwargs,
+    ) -> Path:
+        """Convenience wrapper to convert using a given template."""
+        temp_converter = MarkdownToDocxConverter(
+            reference_doc=template_path, min_pandoc=self.min_pandoc
+        )
+        return temp_converter.convert(input_path, output_path, **kwargs)
 
     def _validate_docx(self, path: Path) -> None:
         """

--- a/src/markdown2docx/templates.py
+++ b/src/markdown2docx/templates.py
@@ -41,16 +41,24 @@ class DocxTemplateManager:
         self.heading_font = heading_font
         self.code_font = code_font
 
-    def create_modern_template(self, output_path: str | Path, *, add_sample: bool = False) -> Path:
-        """Create a modern DOCX template.
+    @classmethod
+    def create_modern_template(
+        cls,
+        output_path: str | Path,
+        *,
+        add_sample: bool = False,
+        **kwargs,
+    ) -> Path:
+        """Create a modern DOCX template using default settings.
 
-        Args:
-            output_path: Where to save the template (e.g., reference.docx).
-            add_sample: If True, inserts minimal sample content to preview styles.
-
-        Returns:
-            Path to the created DOCX file.
+        This convenience classmethod instantiates ``DocxTemplateManager`` with
+        optional keyword arguments and generates a template at ``output_path``.
         """
+        manager = cls(**kwargs)
+        return manager._create_modern_template(output_path, add_sample=add_sample)
+
+    def _create_modern_template(self, output_path: str | Path, *, add_sample: bool = False) -> Path:
+        """Internal helper to build the template on disk."""
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -105,9 +113,9 @@ class DocxTemplateManager:
         # Sizes chosen for readability; adjust as desired
         heading_specs = [
             ("Heading 1", 18, True, 12, 6),
-            ("Heading 2", 16, True, 10, 4),
-            ("Heading 3", 14, True, 8, 3),
-            ("Heading 4", 12, True, 6, 3),
+            ("Heading 2", 14, True, 10, 4),
+            ("Heading 3", 12, True, 8, 3),
+            ("Heading 4", 11, True, 6, 3),
             ("Heading 5", 11, False, 6, 3),
             ("Heading 6", 11, False, 6, 3),
         ]
@@ -196,5 +204,4 @@ class DocxTemplateManager:
     @classmethod
     def create_default_template(cls, output_path: str | Path) -> Path:
         """Create a modern DOCX template with default settings (backward compatibility)."""
-        manager = cls()
-        return manager.create_modern_template(output_path, add_sample=True)
+        return cls.create_modern_template(output_path, add_sample=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,14 +34,15 @@ def hello():
 """
 
 
-def run_cli_command(args, cwd=None):
-    """Helper function to run CLI commands."""
+def run_cli_command(args):
+    """Helper function to run CLI commands from repository root."""
+    repo_root = Path(__file__).resolve().parent.parent
     cmd = [sys.executable, "-m", "src.markdown2docx.cli"] + args
     result = subprocess.run(
-        cmd, 
-        cwd=cwd,
-        capture_output=True, 
-        text=True
+        cmd,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
     )
     return result
 
@@ -53,7 +54,7 @@ def test_cli_basic_conversion(sample_markdown_content):
         input_file = tmpdir_path / "test.md"
         input_file.write_text(sample_markdown_content)
         
-        result = run_cli_command([str(input_file)], cwd=tmpdir_path.parent)
+        result = run_cli_command([str(input_file)])
         
         assert result.returncode == 0
         assert "Successfully converted" in result.stdout
@@ -71,9 +72,9 @@ def test_cli_custom_output(sample_markdown_content):
         input_file.write_text(sample_markdown_content)
         
         result = run_cli_command([
-            str(input_file), 
+            str(input_file),
             "-o", str(output_file)
-        ], cwd=tmpdir_path.parent)
+        ])
         
         assert result.returncode == 0
         assert output_file.exists()
@@ -87,7 +88,7 @@ def test_cli_template_creation():
         
         result = run_cli_command([
             "--create-template", str(template_file)
-        ], cwd=tmpdir_path.parent)
+        ])
         
         assert result.returncode == 0
         assert "Created modern DOCX template" in result.stdout
@@ -105,14 +106,14 @@ def test_cli_with_template(sample_markdown_content):
         # First create template
         result = run_cli_command([
             "--create-template", str(template_file)
-        ], cwd=tmpdir_path.parent)
+        ])
         assert result.returncode == 0
         
         # Then use template for conversion
         result = run_cli_command([
             str(input_file),
             "--template", str(template_file)
-        ], cwd=tmpdir_path.parent)
+        ])
         
         assert result.returncode == 0
         assert "Used template" in result.stdout
@@ -129,7 +130,7 @@ def test_cli_with_toc(sample_markdown_content):
             str(input_file),
             "--toc",
             "--toc-depth", "2"
-        ], cwd=tmpdir_path.parent)
+        ])
         
         assert result.returncode == 0
         assert "Successfully converted" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,23 +42,8 @@ def run_cli_command(args):
         cmd,
         cwd=repo_root,
         capture_output=True,
-        text=True,
-"""Helper function to run CLI commands from repository root."""
-    repo_root = Path(__file__).resolve().parent.parent
-    cmd = [sys.executable, "-m", "src.markdown2docx.cli"] + args
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            check=True
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Command failed with return code {e.returncode}")
-        print(f"Error output: {e.stderr}")
-        return e
-    return result
+        text=True
+    )
     return result
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,22 @@ def run_cli_command(args):
         cwd=repo_root,
         capture_output=True,
         text=True,
-    )
+"""Helper function to run CLI commands from repository root."""
+    repo_root = Path(__file__).resolve().parent.parent
+    cmd = [sys.executable, "-m", "src.markdown2docx.cli"] + args
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed with return code {e.returncode}")
+        print(f"Error output: {e.stderr}")
+        return e
+    return result
     return result
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -105,8 +105,9 @@ def test_convert_with_options(converter, sample_markdown):
         input_path.write_text(sample_markdown)
         
         output_path = converter.convert(
-            input_path, 
-            **{'--toc': True, '--toc-depth': 2}
+            input_path,
+            toc=True,
+            toc_depth=2,
         )
         
         assert output_path.exists()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -155,3 +155,25 @@ def test_converter_with_reference_doc(sample_markdown):
         
         converter = MarkdownToDocxConverter(reference_doc=template_path)
         assert converter.reference_doc == template_path
+
+
+def test_convert_with_template_method(converter, sample_markdown):
+    """Test the convert_with_template method directly."""
+    with TemporaryDirectory() as tmpdir:
+        input_path = Path(tmpdir) / "test.md"
+        template_path = Path(tmpdir) / "template.docx"
+        output_path = Path(tmpdir) / "output.docx"
+        
+        input_path.write_text(sample_markdown)
+        DocxTemplateManager.create_modern_template(template_path)
+        
+        # Test convert_with_template method
+        result = converter.convert_with_template(
+            input_path,
+            template_path,
+            output_path,
+            toc=True
+        )
+        
+        assert result == output_path
+        assert output_path.exists()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -179,6 +179,26 @@ def test_toc_generation(complex_markdown):
         assert output_path.exists()
 
 
+def test_missing_template_handling(complex_markdown, caplog):
+    """Test that missing template files are handled gracefully with warnings."""
+    with TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        input_path = tmpdir_path / "test.md"
+        nonexistent_template = tmpdir_path / "missing_template.docx"
+        
+        input_path.write_text(complex_markdown)
+        
+        # Use converter with non-existent template
+        converter = MarkdownToDocxConverter(reference_doc=nonexistent_template)
+        result = converter.convert(input_path)
+        
+        # Conversion should complete successfully
+        assert result.exists()
+        
+        # Warning should be logged
+        assert "Reference DOCX not found" in caplog.text
+
+
 def test_multilingual_conversion():
     """Test conversion of multilingual content."""
     multilingual_content = """# Multilingual Test 多语言测试

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -169,9 +169,10 @@ def test_toc_generation(complex_markdown):
         
         converter = MarkdownToDocxConverter()
         result = converter.convert(
-            input_path, 
+            input_path,
             output_path,
-            **{'--toc': True, '--toc-depth': 2}
+            toc=True,
+            toc_depth=2,
         )
         
         assert result == output_path
@@ -220,8 +221,12 @@ This paragraph contains both English and 中文 characters in the same line.
         
         # Verify multilingual content is preserved
         doc = Document(output_path)
-        full_text = '\n'.join([p.text for p in doc.paragraphs])
-        
+        full_text = '\n'.join(p.text for p in doc.paragraphs)
+        for table in doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    full_text += '\n' + cell.text
+
         assert '多语言测试' in full_text
         assert '中文部分' in full_text
         assert '你好世界' in full_text

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -10,6 +10,8 @@ from docx import Document
 from docx.enum.style import WD_STYLE_TYPE
 import sys
 from pathlib import Path
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from markdown2docx.templates import DocxTemplateManager
@@ -21,7 +23,7 @@ def test_create_modern_template():
     with TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "modern_template.docx"
         
-        result = DocxTemplateManager.create_modern_template(template_path)
+        result = DocxTemplateManager.create_modern_template(template_path, add_sample=True)
         
         assert result == template_path
         assert template_path.exists()
@@ -42,7 +44,7 @@ def test_template_heading_styles():
     """Test that template has properly configured heading styles."""
     with TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "template.docx"
-        DocxTemplateManager.create_modern_template(template_path)
+        DocxTemplateManager.create_modern_template(template_path, add_sample=True)
         
         doc = Document(template_path)
         
@@ -62,7 +64,7 @@ def test_template_paragraph_styles():
     """Test that template has properly configured paragraph styles."""
     with TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "template.docx"
-        DocxTemplateManager.create_modern_template(template_path)
+        DocxTemplateManager.create_modern_template(template_path, add_sample=True)
         
         doc = Document(template_path)
         
@@ -76,7 +78,7 @@ def test_template_margins():
     """Test that template has correct margin settings."""
     with TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "template.docx"
-        DocxTemplateManager.create_modern_template(template_path)
+        DocxTemplateManager.create_modern_template(template_path, add_sample=True)
         
         doc = Document(template_path)
         section = doc.sections[0]
@@ -110,7 +112,7 @@ Final content.
         output_path = tmpdir_path / "output.docx"
         
         # Create template and input file
-        DocxTemplateManager.create_modern_template(template_path)
+        DocxTemplateManager.create_modern_template(template_path, add_sample=True)
         input_path.write_text(markdown_content)
         
         # Convert using template
@@ -137,7 +139,7 @@ def test_template_code_style():
     """Test that template includes code block style."""
     with TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "template.docx"
-        DocxTemplateManager.create_modern_template(template_path)
+        DocxTemplateManager.create_modern_template(template_path, add_sample=True)
         
         doc = Document(template_path)
         style_names = [style.name for style in doc.styles]
@@ -154,8 +156,7 @@ def test_template_sample_content():
     """Test that template contains sample content for structure."""
     with TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "template.docx"
-        DocxTemplateManager.create_modern_template(template_path)
-        
+        DocxTemplateManager.create_modern_template(template_path, add_sample=True)
         doc = Document(template_path)
         
         # Should have some sample content
@@ -196,10 +197,9 @@ This is test content.
 
 def test_template_error_handling():
     """Test template creation error handling."""
-    # Test with invalid path (should still work, creating directories)
+    # Test with path in a non-existent directory (should create directories)
     with TemporaryDirectory() as tmpdir:
         invalid_path = Path(tmpdir) / "nonexistent" / "template.docx"
-        
-        # This should fail because parent directory doesn't exist
-        with pytest.raises(FileNotFoundError):
-            DocxTemplateManager.create_modern_template(invalid_path)
+
+        result = DocxTemplateManager.create_modern_template(invalid_path)
+        assert result.exists()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -167,6 +167,26 @@ def test_template_sample_content():
         assert len(heading_texts) >= 3  # At least 3 sample headings
 
 
+def test_template_custom_heading_styles():
+    """Test template creation with custom heading styles via kwargs."""
+    with TemporaryDirectory() as tmpdir:
+        template_path = Path(tmpdir) / "custom_template.docx"
+        
+        # Create template with custom heading font
+        DocxTemplateManager.create_modern_template(
+            template_path, 
+            heading_font="Arial",
+            heading1_size=20
+        )
+        
+        doc = Document(template_path)
+        heading1 = doc.styles['Heading 1']
+        
+        # Verify custom styles are applied
+        assert heading1.font.name == 'Arial'
+        assert heading1.font.size.pt == 20
+
+
 def test_template_reusability():
     """Test that template can be used multiple times."""
     markdown_content = """# Document Title

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -172,19 +172,20 @@ def test_template_custom_heading_styles():
     with TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "custom_template.docx"
         
-        # Create template with custom heading font
+        # Create template with custom heading font and code font
         DocxTemplateManager.create_modern_template(
             template_path, 
             heading_font="Arial",
-            heading1_size=20
+            code_font="Courier New"
         )
         
         doc = Document(template_path)
         heading1 = doc.styles['Heading 1']
+        code_style = doc.styles['Code Block']
         
         # Verify custom styles are applied
         assert heading1.font.name == 'Arial'
-        assert heading1.font.size.pt == 20
+        assert code_style.font.name == 'Courier New'
 
 
 def test_template_reusability():


### PR DESCRIPTION
## Summary
- pass CLI options correctly and support template conversion helpers
- expose a classmethod to create DOCX templates and fine-tune heading styles
- adjust tests to exercise CLI and multilingual features from project root

## Testing
- `./scripts/setup-env.sh --group dev`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897d6cb8a60832b81b11a8e82b373d5

## Summary by Sourcery

Add environment setup script with documentation, improve template and converter APIs, refine CLI options, and update tests and CI to support new workflow.

New Features:
- Add scripts/setup-env.sh for installing project and Pandoc dependencies
- Introduce DocxTemplateManager.create_modern_template classmethod with support for custom style parameters
- Add MarkdownToDocxConverter.convert_with_template convenience method

Enhancements:
- Warn instead of error on missing reference DOCX and unify Pandoc argument construction via a helper
- Configure converter logging and adjust template heading sizes for improved defaults
- Refine CLI to accept named options consistently and run commands from repository root

CI:
- Simplify GitHub Actions to invoke setup-env.sh for environment provisioning

Documentation:
- Update README and README_zh to document setup script usage and showcase updated option syntax

Tests:
- Adjust existing tests to use add_sample flag, cover custom heading styles, missing template warnings, multilingual content extraction, convert_with_template, and CLI invocation behavior